### PR TITLE
Fixed redux-axios-middleware patch: 'network' instead of 'nodes' in state

### DIFF
--- a/patches/redux-axios-middleware+4.0.0.patch
+++ b/patches/redux-axios-middleware+4.0.0.patch
@@ -8,7 +8,7 @@ patch-package
 +
 +    function getClientNameFromState (blockchain) {
 +      var state = getState()
-+      var chronobankMiddlewares = state.nodes.selected.chronobankMiddlewares
++      var chronobankMiddlewares = state.network.selected.chronobankMiddlewares
 +      if (!chronobankMiddlewares) {
 +        var networkErrorMessage = 'Network does not selected. Please select main or test network first'
 +        throw new Error(networkErrorMessage)


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ozalexo/chronomint-rn/37)
<!-- Reviewable:end -->
